### PR TITLE
Add prefix 'mtar' to all static functions to reduce chance of conflict

### DIFF
--- a/microtar.c
+++ b/microtar.c
@@ -42,11 +42,11 @@ typedef struct {
   char _padding[255];
 } mtar_raw_header_t;
 
-static size_t round_up(size_t n, size_t incr) {
+static size_t mtar_round_up(size_t n, size_t incr) {
   return n + (incr - n % incr) % incr;
 }
 
-static unsigned checksum(const mtar_raw_header_t* rh) {
+static unsigned mtar_checksum(const mtar_raw_header_t* rh) {
   unsigned i;
   const unsigned char *p = (const unsigned char*) rh;
   unsigned res = 256;
@@ -59,24 +59,24 @@ static unsigned checksum(const mtar_raw_header_t* rh) {
   return res;
 }
 
-static int tread(mtar_t *tar, void *data, size_t size) {
+static int mtar_tread(mtar_t *tar, void *data, size_t size) {
   int err = tar->read(tar, data, size);
   tar->pos += size;
   return err;
 }
 
-static int twrite(mtar_t *tar, const void *data, size_t size) {
+static int mtar_twrite(mtar_t *tar, const void *data, size_t size) {
   int err = tar->write(tar, data, size);
   tar->pos += size;
   return err;
 }
 
-static int write_null_bytes(mtar_t *tar, size_t n) {
+static int mtar_write_null_bytes(mtar_t *tar, size_t n) {
   size_t i;
   int err;
   char nul = '\0';
   for (i = 0; i < n; i++) {
-    err = twrite(tar, &nul, 1);
+    err = mtar_twrite(tar, &nul, 1);
     if (err) {
       return err;
     }
@@ -84,7 +84,7 @@ static int write_null_bytes(mtar_t *tar, size_t n) {
   return MTAR_ESUCCESS;
 }
 
-static int raw_to_header(mtar_header_t *h, const mtar_raw_header_t *rh) {
+static int mtar_raw_to_header(mtar_header_t *h, const mtar_raw_header_t *rh) {
   unsigned chksum1, chksum2;
 #ifdef HAVE_LONG_LONG
   long long size;
@@ -101,7 +101,7 @@ static int raw_to_header(mtar_header_t *h, const mtar_raw_header_t *rh) {
   }
 
   /* Build and compare checksum */
-  chksum1 = checksum(rh);
+  chksum1 = mtar_checksum(rh);
   sscanf(rh->checksum, "%7o", &chksum2);
   if (chksum1 != chksum2) {
     return MTAR_EBADCHKSUM;
@@ -130,7 +130,7 @@ static int raw_to_header(mtar_header_t *h, const mtar_raw_header_t *rh) {
   return MTAR_ESUCCESS;
 }
 
-static int header_to_raw(mtar_raw_header_t *rh, const mtar_header_t *h) {
+static int mtar_header_to_raw(mtar_raw_header_t *rh, const mtar_header_t *h) {
   unsigned chksum;
 
   if (h->size > MTAR_SIZEMAX) {
@@ -156,7 +156,7 @@ static int header_to_raw(mtar_raw_header_t *rh, const mtar_header_t *h) {
   strcpy(rh->linkname, h->linkname);
 
   /* Calculate and write checksum */
-  chksum = checksum(rh);
+  chksum = mtar_checksum(rh);
   sprintf(rh->checksum, "%06o", chksum);
   rh->checksum[7] = ' ';
 
@@ -180,17 +180,17 @@ const char* mtar_strerror(int err) {
   return "unknown error";
 }
 
-static int file_write(mtar_t *tar, const void *data, size_t size) {
+static int mtar_file_write(mtar_t *tar, const void *data, size_t size) {
   size_t res = fwrite(data, 1, size, (FILE *)tar->stream);
   return (res == size) ? MTAR_ESUCCESS : MTAR_EWRITEFAIL;
 }
 
-static int file_read(mtar_t *tar, void *data, size_t size) {
+static int mtar_file_read(mtar_t *tar, void *data, size_t size) {
   size_t res = fread(data, 1, size, (FILE *)tar->stream);
   return (res == size) ? MTAR_ESUCCESS : MTAR_EREADFAIL;
 }
 
-static int file_seek(mtar_t *tar, size_t offset) {
+static int mtar_file_seek(mtar_t *tar, size_t offset) {
 #if defined(HAVE__FSEEKI64) && (defined(_WIN64) || defined(__x86_64__) || defined(__ppc64__))
   int res = _fseeki64((FILE *)tar->stream, offset, SEEK_SET);
 #elif defined(HAVE_FSEEKO) && (defined(_WIN64) || defined(__x86_64__) || defined(__ppc64__))
@@ -201,7 +201,7 @@ static int file_seek(mtar_t *tar, size_t offset) {
   return (res == 0) ? MTAR_ESUCCESS : MTAR_ESEEKFAIL;
 }
 
-static int file_close(mtar_t *tar) {
+static int mtar_file_close(mtar_t *tar) {
   fclose((FILE *)tar->stream);
   return MTAR_ESUCCESS;
 }
@@ -211,10 +211,10 @@ int mtar_open_fp(mtar_t *tar, void *fp) {
   memset(tar, 0, sizeof(*tar));
   if (!fp) return MTAR_EOPENFAIL;
 
-  tar->write = file_write;
-  tar->read = file_read;
-  tar->seek = file_seek;
-  tar->close = file_close;
+  tar->write = mtar_file_write;
+  tar->read = mtar_file_read;
+  tar->seek = mtar_file_seek;
+  tar->close = mtar_file_close;
   tar->stream = fp;
 
   /* Return ok */
@@ -319,7 +319,7 @@ int mtar_next(mtar_t *tar) {
     return err;
   }
   /* Seek to next record */
-  n = round_up(h.size, 512) + sizeof(mtar_raw_header_t);
+  n = mtar_round_up(h.size, 512) + sizeof(mtar_raw_header_t);
   return mtar_seek(tar, tar->pos + n);
 }
 
@@ -358,7 +358,7 @@ int mtar_read_header(mtar_t *tar, mtar_header_t *h) {
   /* Save header position */
   tar->last_header = tar->pos;
   /* Read raw header */
-  err = tread(tar, &rh, sizeof(rh));
+  err = mtar_tread(tar, &rh, sizeof(rh));
   if (err) {
     return err;
   }
@@ -368,7 +368,7 @@ int mtar_read_header(mtar_t *tar, mtar_header_t *h) {
     return err;
   }
   /* Load raw header into header struct and return */
-  return raw_to_header(h, &rh);
+  return mtar_raw_to_header(h, &rh);
 }
 
 int mtar_read_data(mtar_t *tar, void *ptr, size_t size) {
@@ -390,7 +390,7 @@ int mtar_read_data(mtar_t *tar, void *ptr, size_t size) {
     tar->remaining_data = h.size;
   }
   /* Read data */
-  err = tread(tar, ptr, size);
+  err = mtar_tread(tar, ptr, size);
   if (err) {
     return err;
   }
@@ -406,9 +406,9 @@ int mtar_read_data(mtar_t *tar, void *ptr, size_t size) {
 int mtar_write_header(mtar_t *tar, const mtar_header_t *h) {
   mtar_raw_header_t rh;
   /* Build raw header and write */
-  header_to_raw(&rh, h);
+  mtar_header_to_raw(&rh, h);
   tar->remaining_data = h->size;
-  return twrite(tar, &rh, sizeof(rh));
+  return mtar_twrite(tar, &rh, sizeof(rh));
 }
 
 int mtar_write_file_header(mtar_t *tar, const char *name, size_t size) {
@@ -441,21 +441,21 @@ int mtar_write_dir_header(mtar_t *tar, const char *name) {
 int mtar_write_data(mtar_t *tar, const void *data, size_t size) {
   int err;
   /* Write data */
-  err = twrite(tar, data, size);
+  err = mtar_twrite(tar, data, size);
   if (err) {
     return err;
   }
   tar->remaining_data -= size;
   /* Write padding if we've written all the data for this file */
   if (tar->remaining_data == 0) {
-    return write_null_bytes(tar, round_up(tar->pos, 512) - tar->pos);
+    return mtar_write_null_bytes(tar, mtar_round_up(tar->pos, 512) - tar->pos);
   }
   return MTAR_ESUCCESS;
 }
 
 int mtar_finalize(mtar_t *tar) {
   /* Write two NULL records */
-  return write_null_bytes(tar, sizeof(mtar_raw_header_t) * 2);
+  return mtar_write_null_bytes(tar, sizeof(mtar_raw_header_t) * 2);
 }
 
 static int memory_write(mtar_t *tar, const void *data, size_t size) {


### PR DESCRIPTION
Some of static functions have generic names which leads to conflicts with other libraries, prefix 'mtar' added to reduce the chances